### PR TITLE
Fixed sequelize sync bug with model names

### DIFF
--- a/models/Entry.js
+++ b/models/Entry.js
@@ -30,14 +30,14 @@ Entry.init(
     user_id: {
       type: DataTypes.INTEGER,
       references: {
-        model: 'user',
+        model: 'users',
         key: 'id',
       },
     },
     platform_id: {
       type: DataTypes.INTEGER,
       references: {
-        model: 'platform',
+        model: 'platforms',
         key: 'id',
       },
     },


### PR DESCRIPTION
Fixes bug where server.js didn't sync to db due to mismatch of model names in foreign key definitions